### PR TITLE
Replaced <link> tag with @import for failing examples

### DIFF
--- a/dojox/grid/DataGrid.rst
+++ b/dojox/grid/DataGrid.rst
@@ -72,7 +72,7 @@ Grids are familiar in the client/server development world. Basically a grid is a
 
   .. css ::
 
-        <link rel="stylesheet" type="text/css" href="{{baseUrl}}dojox/grid/resources/claroGrid.css" >
+        @import "{{dataUrl}}dojox/grid/resources/claroGrid.css";
 
         /*Grid needs an explicit height by default*/
         #gridDiv {
@@ -460,7 +460,7 @@ This example shows how to create a simple Grid programmatically.
 
   .. css ::
 
-        <link rel="stylesheet" type="text/css" href="{{baseUrl}}dojox/grid/resources/claroGrid.css" >
+        @import "{{dataUrl}}dojox/grid/resources/claroGrid.css";
         
         /*Grid needs an explicit height by default*/
         #gridDiv {
@@ -570,7 +570,7 @@ To get the current selected rows of the grid, you can use the method yourGrid.se
 
   .. css ::
 
-        <link rel="stylesheet" type="text/css" href="{{baseUrl}}dojox/grid/resources/claroGrid.css" >
+        @import "{{dataUrl}}dojox/grid/resources/claroGrid.css";
         
         /*Grid needs an explicit height by default*/
         #gridDiv {
@@ -657,7 +657,7 @@ First, you have to set a editor for each cell, you would like to edit:
 
   .. css ::
 
-        <link rel="stylesheet" type="text/css" href="{{baseUrl}}dojox/grid/resources/claroGrid.css" >
+        @import "{{dataUrl}}dojox/grid/resources/claroGrid.css";
         
         /*Grid needs an explicit height by default*/
         #gridDiv {
@@ -768,7 +768,7 @@ Since DataGrid is "DataStoreAware", changes made to the store will be reflected 
 
   .. css ::
 
-        <link rel="stylesheet" type="text/css" href="{{baseUrl}}dojox/grid/resources/claroGrid.css" >
+        @import "{{dataUrl}}dojox/grid/resources/claroGrid.css";
         
         /*Grid needs an explicit height by default*/
         #gridDiv {
@@ -865,7 +865,7 @@ The Grid offers a filter() method, to filter data from the current query (client
 
   .. css ::
 
-        <link rel="stylesheet" type="text/css" href="{{baseUrl}}dojox/grid/resources/claroGrid.css" >
+        @import "{{dataUrl}}dojox/grid/resources/claroGrid.css";
         
         /*Grid needs an explicit height by default*/
         #gridDiv {
@@ -951,7 +951,7 @@ To use it, you just have to override default behavior by yours.
 
   .. css ::
 
-        <link rel="stylesheet" type="text/css" href="{{baseUrl}}dojox/grid/resources/claroGrid.css" >
+        @import "{{dataUrl}}dojox/grid/resources/claroGrid.css";
         
         /*Grid needs an explicit height by default*/
         #gridDiv {


### PR DESCRIPTION
This is to fix the @import issue for CSS files and it concerns only the first 7 of the 12 examples on the page. Latter 5 work fine (as they don't use explicit styling).

For this fix, I put the @import back in for <link> tags where an explicit CSS styling is required, e.g. #gridDiv{height:20em;}. I have also replaced baseUrl with dataUrl in curly brackets, however I had no way to test it locally. If this fix can not resolve the issue, I need help/ideas!

(I setup rstwiki locally, but it doesn't allow running examples like it is on the website, so can't test it. Is this normal or is my rstwiki setup incorrect?)
