### PR TITLE
refs 16196 Document the use of optimizeOptions 

### DIFF
--- a/build/qref.rst
+++ b/build/qref.rst
@@ -387,6 +387,10 @@ Transform: writeOptimized
 **Important**: Dead code removal consequent to static has.js feature values and the hasFixup transform requires a Google
   Closure or UglifyJS compiler optimization switch setting. To use UglifyJS, you will need to ``npm install uglify-js@1``, in a directory parallel to ``util``
 
+``optimizeOptions`` (default = "undefined")
+    This object is passed to the JavaScript optimizer to allow for compiler specific settings. Settings for UglifyJS and closure 
+    compiler can be set using this object.
+
 ``stripConsole`` (default = "normal")
   * ["none"] No console applications are stripped.
 


### PR DESCRIPTION
While investigating [16196](https://bugs.dojotoolkit.org/ticket/16196), I found that `optimizeOptions` is passed to both uglify and closure when optimizing JS code during a build. This allows us to pass options directly to the compiler from a build profile. 
