### PR TITLE
Adds link to new location of markup.rst/html, fixes #18538

### DIFF
--- a/util/markup.rst
+++ b/util/markup.rst
@@ -1,0 +1,2 @@
+
+This page has been moved to :ref:`Dojo Inline Documentation Format <developer/markup>`


### PR DESCRIPTION
Fixes issue brought up in documentation feedback where markup.html isn't found for Dojo 1.8 and above. The file has been moved from ```/util/doctools/markup.rst``` to ```/developer/markup.rst```