### PR TITLE
Fixing a few minor typos from documentation feedback list

### DIFF
--- a/dojo/date/locale/parse.rst
+++ b/dojo/date/locale/parse.rst
@@ -31,7 +31,7 @@ Usage
     locale.parse("Tuesday, 13 January 2010 12:43:06 GMT-0:00");
     
     // Parse a short date in a specific locale
-    locale.parser("13/01/2010", {
+    locale.parse("13/01/2010", {
       locale: "en-gb",
       formatLength: "short",
       selector: "date"

--- a/dojo/dom-construct.rst
+++ b/dojo/dom-construct.rst
@@ -99,7 +99,7 @@ Usage
   
     require(["dojo/dom-construct"], function(domConstruct){
       domConstruct.place("someNode", "refNode", "after");
-    };
+    });
 
 ``place()`` returns the node it placed. In case of an HTML fragment, if it has just one root element, that element is
 returned directly. Otherwise a document fragment is returned. The returned node can be:

--- a/dojo/has.rst
+++ b/dojo/has.rst
@@ -30,7 +30,7 @@ the same feature.
 Dojo Core and Dijit modules make use of ``dojo/has`` feature detection.  There are still a number of DojoX projects 
 that continue to use ``dojo.isXXX`` user agent sniffing.  This conversion is an ongoing process.
 
-``dojo/has`` can be used a loader plugin with a ternary conditional expression so that modules can be loaded 
+``dojo/has`` can be used as a loader plugin with a ternary conditional expression so that modules can be loaded 
 conditionally.
 
 The basic tests defined within the ``dojo/has`` module can be enhanced with other modules registering additional 

--- a/dojo/regexp.rst
+++ b/dojo/regexp.rst
@@ -14,7 +14,7 @@ Usage
 
 .. js ::
 
-  require["dojo/rexexp"], function(regexp){
+  require["dojo/regexp"], function(regexp){
     // Escape regular expression strings
     var str = regexp.escapeString(someString);
 

--- a/dojo/xhrPut.rst
+++ b/dojo/xhrPut.rst
@@ -26,9 +26,9 @@ The limitations are the same as :ref:`dojo.xhrGet <dojo/xhrGet>`
 Usage
 =====
 
-The xhrPut() function takes an object as its parameter.  This object defines how the xhrPost should operate.  All the :ref:`dojo.xhrGet parameters <dojo/xhrGet>` are valid, including how to set the load and errors handlers.  So, for specific information about those parameters, please refer to dojo.xhrGet.  This page only lists out the parameters which are usually only used in conjunction with with a PUT.
+The xhrPut() function takes an object as its parameter.  This object defines how the xhrPut should operate.  All the :ref:`dojo.xhrGet parameters <dojo/xhrGet>` are valid, including how to set the load and errors handlers.  So, for specific information about those parameters, please refer to dojo.xhrGet.  This page only lists out the parameters which are usually only used in conjunction with with a PUT.
 
-dojo.xhrPost supported object properties
+dojo.xhrPut supported object properties
 ----------------------------------------
 
 All of the dojo.xhrGet :ref:`object properties <dojo/xhrGet>`
@@ -49,7 +49,7 @@ The return type is the same as dojo.xhrGet.  Please refer to the :ref:`return ty
 Handling Status Codes
 ---------------------
 
-Handling status codes for xhrPost is the same as handling them for xhrGet.  Please refer to the dojo.xhrGet :ref:`status code documentation <dojo/xhrGet>` for details.
+Handling status codes for xhrPut is the same as handling them for xhrGet.  Please refer to the dojo.xhrGet :ref:`status code documentation <dojo/xhrGet>` for details.
 
 Examples
 ========
@@ -85,7 +85,7 @@ Example 1: dojo.xhrPut call to send some text data
             }
           }
           dojo.byId("response2").innerHTML = "Message being sent..."
-          // Call the asynchronous xhrPost
+          // Call the asynchronous xhrPut
           var deferred = dojo.xhrPut(xhrArgs);
         });
       }

--- a/dojox/collections.rst
+++ b/dojox/collections.rst
@@ -180,7 +180,7 @@ The dojox.collections.Queue class implements a first-in first-out collection of 
     The number of elements in this collection.
 
 
-SorteList
+SortedList
 ~~~~~~~~~
 
 The dojox.collections.SortedList class implements a collection that acts like a dictionary but is also internally sorted. Note that the act of adding any elements forces an internal resort, making this object potentially slow.


### PR DESCRIPTION
Fixing a few typos pointed out in feedback for the Reference Guide.