### PR TITLE
Adding back double-quote to DataGrid element

### DIFF
--- a/dojox/grid/example_Adding_and_deleting_data.rst
+++ b/dojox/grid/example_Adding_and_deleting_data.rst
@@ -32,7 +32,7 @@ Since DataGrid is "DataStoreAware", changes made to the store will be reflected 
         query:{ name: '*' },
         rowsPerPage:20,
         clientSort:true,
-        rowSelector:'20px'
+        rowSelector:'20px'"
         style="width: 400px; height: 200px;">
         <thead>
             <tr>


### PR DESCRIPTION
Example was broken due to missing double-quote terminating 'data-dojo-props' attribute for the DataGrid element.