### PR TITLE
Fixing RST syntax in calendar.rst

### DIFF
--- a/dojox/calendar.rst
+++ b/dojox/calendar.rst
@@ -9,7 +9,7 @@ dojox.calendar
 dojox.calendar allows to display events in time and edit them.
 
 .. contents ::
-:depth: 3
+  :depth: 3
 
 Introduction
 =============
@@ -74,10 +74,10 @@ You can create a calendar widget either with markup or programmatically.
 The following example shows how to declare a calendar widget in markup:
 
 .. code-example::
-:width: 620
-      :height: 620
+  :width: 620
+  :height: 620
 
-      .. js ::
+  .. js ::
 
     require(["dojo/ready", "dojox/calendar/Calendar"]);
 
@@ -96,8 +96,8 @@ The following example shows how to declare a calendar widget in markup:
 The following example shows how to declare a calendar widget programmatically:
 
 .. code-example::
-:width: 620
-      :height: 620
+  :width: 620
+  :height: 620
 
       .. js ::
 
@@ -1146,7 +1146,7 @@ If the calendar instance is already declared, use this syntax:
 
 .. js ::
 
-calendar.columnView.set(myColumnViewProperty, value);
+  calendar.columnView.set(myColumnViewProperty, value);
 
 
 Properties
@@ -1385,7 +1385,7 @@ If the calendar instance is already declared, use this syntax:
 
 .. js ::
 
-calendar.matrixView.set(myMatrixViewProperty, value);
+  calendar.matrixView.set(myMatrixViewProperty, value);
 
 
 


### PR DESCRIPTION
My previous commit (2201a5d002c4646ed1be6e9fe0a7c140f75b7fce) broke the markup indentation of the document in a few places. This should clear those up.