### PR TITLE
Docs and example for array map in substitute

### DIFF
--- a/dojo/string.rst
+++ b/dojo/string.rst
@@ -25,7 +25,7 @@ Usage
 pad()
 -----
 
-Pad a string to guarantee that it is at least ``size`` length by filling with the character ``ch`` at either the start 
+Pad a string to guarantee that it is at least ``size`` length by filling with the character ``ch`` at either the start
 or end of the string. Pads at the start, by default.
 
 rep()
@@ -36,12 +36,13 @@ Repeats a string a certain number of times.
 substitute()
 ------------
 
-``substitute()`` is a workhorse and the basis for Dijit's templating.  It performs parameterized substitution in the 
-form of ``${name}`` with a variety of advanced options.  An object is provided as the hashtable to lookup when doing 
-these substitutions. The expression in the curly braces may be a simple property, like ``name`` or a dotted expression 
-like ``data.employee.name``.  The expression may be further qualified by a colon and the name of a format function, to 
-run the output each lookup through a property, such as ``mylib.formatName``.   A ``this`` reference may be provided 
-for the format function, otherwise it will be scoped to the global namespace.  Lastly, an optional transform function 
+``substitute()`` is a workhorse and the basis for Dijit's templating.  It performs parameterized substitution in the
+form of ``${name}`` with a variety of advanced options.  An object is provided as the hashtable to lookup when doing
+these substitutions. The expression in the curly braces may be a simple property, like ``name`` or a dotted expression
+like ``data.employee.name``.  Alternatively, an array may be provided and indices referenced like ``${0}``.  The
+expression may be further qualified by a colon and the name of a format function, to
+run the output each lookup through a property, such as ``mylib.formatName``.   A ``this`` reference may be provided
+for the format function, otherwise it will be scoped to the global namespace.  Lastly, an optional transform function
 can be run on all properties just prior to substitution, such as one to escape HTML entities.
 
 .. _dojo/string#trim:
@@ -52,7 +53,7 @@ trim()
 ``trim()`` trims whitespace off both ends of a string.
 
 This will default to the ES5 String.prototype.trim if available, otherwise it will utilise a more performant, but not
-very compact version of the ``trim()``, which is different than the ``trim()`` which is included in 
+very compact version of the ``trim()``, which is different than the ``trim()`` which is included in
 :ref:`dojo/_base/lang`.
 
 Examples
@@ -94,7 +95,7 @@ Examples
 .. code-example ::
   :djConfig: async: true, parseOnLoad: false
 
-  An example of ``substitute()``.
+  An example of ``substitute()`` using an object map.
 
   .. js ::
 
@@ -106,6 +107,23 @@ Examples
   .. html ::
 
     <div id="input">${replace} has the hots for ${me}</div>
+    <div id="output"></div>
+
+.. code-example ::
+  :djConfig: async: true, parseOnLoad: false
+
+  An example of ``substitute()`` using an array map.
+
+  .. js ::
+
+    require(["dojo/string", "dojo/dom", "dojo/domReady!"],
+    function(string, dom){
+      dom.byId("output").innerHTML = string.substitute(dom.byId("input").innerHTML, ["foo", "bar"]);
+    });
+
+  .. html ::
+
+    <div id="input">${0} has the hots for ${1}</div>
     <div id="output"></div>
 
 .. code-example ::


### PR DESCRIPTION
I can never remember if I can use an array map with substitute.

Here's the JSBin of the new example for verification: http://jsbin.com/walopeloko/1/edit?html,js,output