### PR TITLE
Fix bug in example code for dynamic loading of drop-downs

### DIFF
--- a/dijit/_HasDropDown.rst
+++ b/dijit/_HasDropDown.rst
@@ -109,7 +109,7 @@ In order to work around these limitations, more advanced drop-down widgets can i
               var dropDown = this.dropDown;
               if(!dropDown){ return; }
               if(!this.isLoaded()){
-                  var handler = dropDown.on("load", this, function(){
+                  var handler = dropDown.on("load", function(){
                       handler.remove();
                       callback();
                   });


### PR DESCRIPTION
The on() method of widgets takes only two arguments.