### PR TITLE
Update dojox/gesture doc with warning about events

### DIFF
--- a/dojox/gesture.rst
+++ b/dojox/gesture.rst
@@ -75,6 +75,8 @@ The common parental class for all gesture implementations. It takes most routine
 
 3. Fire and bubble gesture events.
 
+Caution: to ensure that gestures work properly across all supported devices, dojox/gesture/Base prevents the default action on events, with the exception being events fired on form elements. As a result, it is best to apply gestures to specific elements, rather than to their ancestor nodes.
+
 
 dojox/gesture/tap
 =================


### PR DESCRIPTION
Add a warning to the `dojox/gesture` documentation explaining that `dojox/gesture/Base` prevents the default action on all events emitted from non-form field elements.